### PR TITLE
Danrlu/move to fork

### DIFF
--- a/scripts/join-metadata-and-clades.py
+++ b/scripts/join-metadata-and-clades.py
@@ -125,9 +125,9 @@ def main():
     offset_by_clade = {}
     for clade in all_clades:
         ind = result.Nextstrain_clade==clade
-        if ind.sum()>100:
+        if ind.sum()>4:
             deviation = div_array[ind] - (t[ind] - reference_day)*rate_per_day
-            offset_by_clade[clade] = np.mean(deviation[~np.isnan(deviation)])
+            offset_by_clade[clade] = np.median(deviation[~np.isnan(deviation)])
 
     # extract divergence, time and offset information into vectors or series
     offset = result["Nextstrain_clade"].apply(lambda x: offset_by_clade.get(x, 2.0))

--- a/workflow/snakemake_rules/main_workflow.smk
+++ b/workflow/snakemake_rules/main_workflow.smk
@@ -254,9 +254,10 @@ rule index_sequences:
     conda: config["conda_environment"]
     shell:
         """
-        augur index \
-            --sequences {input.sequences} \
-            --output {output.sequence_index} 2>&1 | tee {log}
+        unxz --stdout {input.sequences} \
+            | seqtk comp -u - \
+            | sed '1i strain\tlength\tA\tC\tG\tT\tmix2\tmix3\tN\tCpG\ttransversion\ttransition\tCpG_ts' \
+            | xz -c -2 > {output.sequence_index} 2>&1 | tee {log}
         """
 
 rule subsample:


### PR DESCRIPTION
1. Fold in our patch to the forked `ncov` to replace `augur index` with `seqtk` (see https://github.com/nextstrain/ncov/pull/814). 
2. Stopgap: relax the calculation of `offset` to bring back BA.2 samples on the tree. See full description here: https://github.com/nextstrain/ncov/issues/874

Changes are currently on the `master` branch of this fork, pending best practice learnings w Jess for improvement. 